### PR TITLE
fix(broker): scope slash rewrite per-profile (no cross-profile skill/alias leak)

### DIFF
--- a/hermes_multitenancy/run_broker.py
+++ b/hermes_multitenancy/run_broker.py
@@ -114,24 +114,30 @@ def _rewrite_skill_slash_request(request: RunRequest) -> RunRequest:
     # _profile_home_context already hold — re-acquiring it here would deadlock). Reusing a
     # profile we're already scoped to (Feishu re-entry) is a harmless idempotent no-op.
     states: list = []
-    if request.profile_name:
-        try:
-            from . import router  # lazy import: router imports run_broker (avoid cycle)
+    scoped = False
+    try:
+        from . import router  # lazy import: router imports run_broker (avoid cycle)
 
-            profile_home = router._profile_name_to_home(request.profile_name)
-            states = router._scope_profile_skill_loader(profile_home)
-        except Exception:  # never let scoping break the slash path
-            states = []
+        profile_home = router._profile_name_to_home(request.profile_name)
+        states = router._scope_profile_skill_loader(profile_home)
+        scoped = bool(states)
+    except Exception:
+        scoped = False
+    if not scoped:
+        # FAIL CLOSED: if we cannot scope the skill loader to THIS profile, we must not
+        # run the rewrite against a stale process-global cache — that would resolve the
+        # command against whatever profile ran last (the exact cross-profile leak this
+        # fixes). Leave the text untouched; a real command just passes through unrewritten.
+        return request
     try:
         rewritten = rewrite_skill_slash_text(request.content, task_id=task_id, platform=platform)
     finally:
-        if states:
-            try:
-                from . import router
+        try:
+            from . import router
 
-                router._restore_profile_skill_loader(states)
-            except Exception:
-                pass
+            router._restore_profile_skill_loader(states)
+        except Exception:
+            pass
     if not rewritten or rewritten == request.content:
         return request
     return replace(request, content=rewritten)

--- a/hermes_multitenancy/run_broker.py
+++ b/hermes_multitenancy/run_broker.py
@@ -102,7 +102,36 @@ def _rewrite_skill_slash_request(request: RunRequest) -> RunRequest:
         f"{request.chat_id or 'run-broker'}:{request.user_key}"
     )
     platform = request.channel if request.channel == "feishu" else None
-    rewritten = rewrite_skill_slash_text(request.content, task_id=task_id, platform=platform)
+    # Scope the core skill-command loader to THIS request's profile so the slash rewrite
+    # resolves against the profile's own installed skills (incl. their slash_aliases),
+    # not a stale process-global cache left by whichever profile ran last. The Feishu
+    # path already scopes before its rewrite; the webui/cron broker entry did not, which
+    # leaked one profile's skill/alias commands into another's resolution.
+    #
+    # This whole block is SYNCHRONOUS (no await between scope-set and restore), so in
+    # single-threaded asyncio there is no interleaving point: no lock is needed, there is
+    # no race, and we never touch the non-reentrant env lock (which the Feishu path /
+    # _profile_home_context already hold — re-acquiring it here would deadlock). Reusing a
+    # profile we're already scoped to (Feishu re-entry) is a harmless idempotent no-op.
+    states: list = []
+    if request.profile_name:
+        try:
+            from . import router  # lazy import: router imports run_broker (avoid cycle)
+
+            profile_home = router._profile_name_to_home(request.profile_name)
+            states = router._scope_profile_skill_loader(profile_home)
+        except Exception:  # never let scoping break the slash path
+            states = []
+    try:
+        rewritten = rewrite_skill_slash_text(request.content, task_id=task_id, platform=platform)
+    finally:
+        if states:
+            try:
+                from . import router
+
+                router._restore_profile_skill_loader(states)
+            except Exception:
+                pass
     if not rewritten or rewritten == request.content:
         return request
     return replace(request, content=rewritten)

--- a/hermes_multitenancy/run_broker.py
+++ b/hermes_multitenancy/run_broker.py
@@ -115,15 +115,31 @@ def _rewrite_skill_slash_request(request: RunRequest) -> RunRequest:
     # profile we're already scoped to (Feishu re-entry) is a harmless idempotent no-op.
     states: list = []
     scoped = False
+    router = None
     try:
         from . import router  # lazy import: router imports run_broker (avoid cycle)
 
         profile_home = router._profile_name_to_home(request.profile_name)
         states = router._scope_profile_skill_loader(profile_home)
-        scoped = bool(states)
+        # `_scope_profile_skill_loader` is best-effort and silently skips a failed import,
+        # so a non-empty `states` does NOT prove the loader is pointed at this profile.
+        # Verify the ACTUAL post-conditions: both the skills dir and the command cache must
+        # be scoped, or resolution would still run against the previous profile's state.
+        import tools.skills_tool as _st  # type: ignore
+        import agent.skill_commands as _sc  # type: ignore
+
+        scoped = (
+            getattr(_st, "SKILLS_DIR", None) == profile_home / "skills"
+            and getattr(_sc, "_skill_commands", None) == {}
+        )
     except Exception:
         scoped = False
     if not scoped:
+        if states and router is not None:  # restore any partial scoping before bailing
+            try:
+                router._restore_profile_skill_loader(states)
+            except Exception:
+                pass
         # FAIL CLOSED: if we cannot scope the skill loader to THIS profile, we must not
         # run the rewrite against a stale process-global cache — that would resolve the
         # command against whatever profile ran last (the exact cross-profile leak this
@@ -133,8 +149,6 @@ def _rewrite_skill_slash_request(request: RunRequest) -> RunRequest:
         rewritten = rewrite_skill_slash_text(request.content, task_id=task_id, platform=platform)
     finally:
         try:
-            from . import router
-
             router._restore_profile_skill_loader(states)
         except Exception:
             pass

--- a/hermes_multitenancy/run_broker.py
+++ b/hermes_multitenancy/run_broker.py
@@ -123,15 +123,13 @@ def _rewrite_skill_slash_request(request: RunRequest) -> RunRequest:
         states = router._scope_profile_skill_loader(profile_home)
         # `_scope_profile_skill_loader` is best-effort and silently skips a failed import,
         # so a non-empty `states` does NOT prove the loader is pointed at this profile.
-        # Verify the ACTUAL post-conditions: both the skills dir and the command cache must
-        # be scoped, or resolution would still run against the previous profile's state.
-        import tools.skills_tool as _st  # type: ignore
-        import agent.skill_commands as _sc  # type: ignore
-
-        scoped = (
-            getattr(_st, "SKILLS_DIR", None) == profile_home / "skills"
-            and getattr(_sc, "_skill_commands", None) == {}
-        )
+        # Verify BOTH required mutations actually happened by inspecting the states it
+        # returned — the SKILLS_DIR redirect AND the command-cache reset. If either was
+        # skipped, the rewrite could still resolve against the previous profile's state.
+        # (Inspecting states avoids hard-importing tools.skills_tool here, which would make
+        # every rewrite depend on that import even where the loader itself handles it.)
+        mutated = {attr for (_m, attr, _old, _had) in states}
+        scoped = "SKILLS_DIR" in mutated and "_skill_commands" in mutated
     except Exception:
         scoped = False
     if not scoped:

--- a/tests/test_run_broker.py
+++ b/tests/test_run_broker.py
@@ -351,6 +351,12 @@ def test_run_broker_rewrites_hades_alias_before_dispatch(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "agent", ModuleType("agent"))
     monkeypatch.setitem(sys.modules, "agent.skill_commands", fake_skill_commands)
+    # the broker now scopes the skill loader per-profile before rewriting; stub
+    # tools.skills_tool so _scope_profile_skill_loader can set SKILLS_DIR in any env
+    # (the per-profile scope must establish, or the rewrite fails closed).
+    fake_skills_tool = SimpleNamespace(HERMES_HOME=None, SKILLS_DIR=None)
+    monkeypatch.setitem(sys.modules, "tools", ModuleType("tools"))
+    monkeypatch.setitem(sys.modules, "tools.skills_tool", fake_skills_tool)
 
     seen = []
 

--- a/tests/test_run_broker_slash_scope.py
+++ b/tests/test_run_broker_slash_scope.py
@@ -87,11 +87,20 @@ def test_global_loader_state_restored_after_rewrite(two_profiles):
     assert getattr(sc, "_skill_commands", None) == before_cmds
 
 
-def test_no_profile_is_safe_noop(monkeypatch):
-    # a rewrite with an unresolvable profile must not raise (scoping fails soft)
+@requires_agent
+def test_fail_closed_when_scoping_fails_does_not_leak_global(two_profiles, monkeypatch):
+    # poison the global cache with profile A's strategy command, then make scoping FAIL.
+    # A slash command must NOT resolve from that stale global cache (fail closed).
+    run_broker._rewrite_skill_slash_request(_req("pA", "/strategy x"))  # populate global
     from hermes_multitenancy import router
-    def _boom(_name):
-        raise RuntimeError("no home")
-    monkeypatch.setattr(router, "_profile_name_to_home", _boom)
-    out = run_broker._rewrite_skill_slash_request(_req("pX", "hello world"))
-    assert out.content == "hello world"
+    monkeypatch.setattr(router, "_scope_profile_skill_loader", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")))
+    out = run_broker._rewrite_skill_slash_request(_req("pB", "/strategy x"))
+    assert out.content == "/strategy x"  # unresolved — did NOT fall back to A's global cache
+
+
+def test_scoping_helper_failure_is_safe_noop(monkeypatch):
+    # scoping mechanism unavailable → fail closed, no raise, text untouched
+    from hermes_multitenancy import router
+    monkeypatch.setattr(router, "_profile_name_to_home", lambda _n: (_ for _ in ()).throw(RuntimeError("no home")))
+    out = run_broker._rewrite_skill_slash_request(_req("pX", "/strategy hello"))
+    assert out.content == "/strategy hello"

--- a/tests/test_run_broker_slash_scope.py
+++ b/tests/test_run_broker_slash_scope.py
@@ -1,0 +1,97 @@
+"""Broker slash rewrite is scoped per-profile (no cross-profile skill/alias leak).
+
+Webui/cron enter via RunBroker; the slash rewrite must resolve against the REQUEST's
+profile skills, not a stale process-global cache from whichever profile ran last.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_multitenancy import run_broker
+from hermes_multitenancy.run_models import RunRequest
+
+# the rewrite delegates to core agent.skill_commands; skip cleanly if a thin env lacks it
+try:
+    import agent.skill_commands  # noqa: F401
+    _HAS_AGENT = True
+except Exception:
+    _HAS_AGENT = False
+requires_agent = pytest.mark.skipif(not _HAS_AGENT, reason="agent.skill_commands not installed")
+
+
+def _install_skill(profile_home, name, *, slash_aliases=None):
+    d = profile_home / "skills" / name
+    d.mkdir(parents=True, exist_ok=True)
+    fm = f"name: {name}\n"
+    if slash_aliases:
+        fm += f"slash_aliases: [{', '.join(slash_aliases)}]\n"
+    (d / "SKILL.md").write_text(f"---\n{fm}description: d\n---\n# {name}\n", encoding="utf-8")
+
+
+@pytest.fixture
+def two_profiles(tmp_path, monkeypatch):
+    root = tmp_path / "profiles"
+    a, b = root / "pA", root / "pB"
+    (a / "skills").mkdir(parents=True)
+    (b / "skills").mkdir(parents=True)
+    # profile A has the strategy skill (with its short alias); B has none
+    _install_skill(a, "kep-trevi-strategy-recommend", slash_aliases=["strategy"])
+
+    from hermes_multitenancy import router
+    monkeypatch.setattr(router, "_profile_name_to_home", lambda name: root / name)
+    # start from a clean global skill cache + neutral SKILLS_DIR
+    import agent.skill_commands as sc
+    import tools.skills_tool as st
+    monkeypatch.setattr(sc, "_skill_commands", {}, raising=False)
+    from hermes_multitenancy import skill_slash
+    skill_slash._ALIAS_SCAN_CACHE.clear()
+    return root, st, sc
+
+
+def _req(profile, content):
+    return RunRequest(channel="webui", profile_name=profile, user_key="u", content=content)
+
+
+@requires_agent
+def test_alias_resolves_for_owning_profile(two_profiles):
+    out = run_broker._rewrite_skill_slash_request(_req("pA", "/strategy 首页大卡"))
+    assert out.content != "/strategy 首页大卡"
+    assert "kep-trevi-strategy-recommend" in out.content
+
+
+@requires_agent
+def test_alias_does_not_leak_to_other_profile(two_profiles):
+    # resolve for A first (populates the global cache), then B must NOT inherit it
+    run_broker._rewrite_skill_slash_request(_req("pA", "/strategy x"))
+    out_b = run_broker._rewrite_skill_slash_request(_req("pB", "/strategy x"))
+    assert out_b.content == "/strategy x"  # B has no strategy skill → unresolved, not A's
+
+
+@requires_agent
+def test_full_name_command_also_per_profile(two_profiles):
+    # the pre-existing /full-name path is fixed by the same scoping
+    out_a = run_broker._rewrite_skill_slash_request(_req("pA", "/kep-trevi-strategy-recommend x"))
+    assert "kep-trevi-strategy-recommend" in out_a.content
+    out_b = run_broker._rewrite_skill_slash_request(_req("pB", "/kep-trevi-strategy-recommend x"))
+    assert out_b.content == "/kep-trevi-strategy-recommend x"
+
+
+@requires_agent
+def test_global_loader_state_restored_after_rewrite(two_profiles):
+    _root, st, sc = two_profiles
+    before_dir = getattr(st, "SKILLS_DIR", None)
+    before_cmds = getattr(sc, "_skill_commands", None)
+    run_broker._rewrite_skill_slash_request(_req("pA", "/strategy x"))
+    # no side-effect leak: the global loader state is restored to what it was
+    assert getattr(st, "SKILLS_DIR", None) == before_dir
+    assert getattr(sc, "_skill_commands", None) == before_cmds
+
+
+def test_no_profile_is_safe_noop(monkeypatch):
+    # a rewrite with an unresolvable profile must not raise (scoping fails soft)
+    from hermes_multitenancy import router
+    def _boom(_name):
+        raise RuntimeError("no home")
+    monkeypatch.setattr(router, "_profile_name_to_home", _boom)
+    out = run_broker._rewrite_skill_slash_request(_req("pX", "hello world"))
+    assert out.content == "hello world"

--- a/tests/test_run_broker_slash_scope.py
+++ b/tests/test_run_broker_slash_scope.py
@@ -87,15 +87,39 @@ def test_global_loader_state_restored_after_rewrite(two_profiles):
     assert getattr(sc, "_skill_commands", None) == before_cmds
 
 
+def _populate_stale_global_with_A(root):
+    """Leave the process-global loader state pointed at profile A with A's commands cached,
+    simulating a prior A run — the stale state a B request must NOT resolve against."""
+    import agent.skill_commands as sc
+    import tools.skills_tool as st
+    st.SKILLS_DIR = root / "pA" / "skills"
+    sc._skill_commands = {}
+    sc.get_skill_commands()  # cache A's /strategy in the global
+    assert sc._skill_commands, "precondition: A's commands populated in the global cache"
+
+
 @requires_agent
-def test_fail_closed_when_scoping_fails_does_not_leak_global(two_profiles, monkeypatch):
-    # poison the global cache with profile A's strategy command, then make scoping FAIL.
-    # A slash command must NOT resolve from that stale global cache (fail closed).
-    run_broker._rewrite_skill_slash_request(_req("pA", "/strategy x"))  # populate global
+def test_fail_closed_when_scoping_raises_does_not_leak_global(two_profiles, monkeypatch):
+    root, _st, _sc = two_profiles
+    _populate_stale_global_with_A(root)
     from hermes_multitenancy import router
-    monkeypatch.setattr(router, "_scope_profile_skill_loader", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(router, "_scope_profile_skill_loader",
+                        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")))
     out = run_broker._rewrite_skill_slash_request(_req("pB", "/strategy x"))
-    assert out.content == "/strategy x"  # unresolved — did NOT fall back to A's global cache
+    assert out.content == "/strategy x"  # fail closed: NOT resolved from A's stale global cache
+
+
+@requires_agent
+def test_partial_scope_without_skills_dir_fails_closed(two_profiles, monkeypatch):
+    # codex's exact concern: scope helper returns non-empty states but did NOT set
+    # SKILLS_DIR to B (e.g. tools.skills_tool import skipped). Post-condition check must
+    # catch this and fail closed rather than rewrite against A's stale SKILLS_DIR.
+    root, _st, _sc = two_profiles
+    _populate_stale_global_with_A(root)
+    from hermes_multitenancy import router
+    monkeypatch.setattr(router, "_scope_profile_skill_loader", lambda _home: [("fake", "x", None, False)])
+    out = run_broker._rewrite_skill_slash_request(_req("pB", "/strategy x"))
+    assert out.content == "/strategy x"  # SKILLS_DIR still at A → scoped=False → fail closed
 
 
 def test_scoping_helper_failure_is_safe_noop(monkeypatch):


### PR DESCRIPTION
Fixes the webui/cron Run Broker slash rewrite leaking one profile's skill/alias commands into another's resolution (the Feishu path already scoped; the broker entry did not). Synchronous SKILLS_DIR + _skill_commands scope around the rewrite — no lock, no race, no deadlock; fails closed if scoping can't establish. codex cross-model review: pass. 19 broker+scope tests green (gate env). Builds on slash_aliases (PR #6).